### PR TITLE
Added a check for an existing geocoding request to ensure rate limit …

### DIFF
--- a/ReverseGeocode/ViewController.swift
+++ b/ReverseGeocode/ViewController.swift
@@ -10,10 +10,12 @@ import UIKit
 import CoreLocation
 
 class ViewController: UIViewController {
-
+    
     @IBOutlet weak var countryLabel: UILabel!
     @IBOutlet weak var localityLabel: UILabel!
     @IBOutlet weak var zipLabel: UILabel!
+    
+    lazy var geocoder = CLGeocoder()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -21,21 +23,26 @@ class ViewController: UIViewController {
         var location = CLLocation(latitude: 37.33233141, longitude: -122.0312186)
         reverseGeocode(location)
     }
-
+    
     func reverseGeocode(location: CLLocation) {
-        CLGeocoder().reverseGeocodeLocation(location, completionHandler: {(placemarks, error) -> Void in
-            if error != nil {
-                println("Reverse geocoder failed with error" + error.localizedDescription)
-                return
-            }
-            if placemarks.count > 0 {
-                if let placemark = placemarks.last as? CLPlacemark {
-                    self.updateView(placemark)
+        if !self.geocoder.geocoding {
+            self.geocoder.reverseGeocodeLocation(location, completionHandler: {(placemarks, error) -> Void in
+                if error != nil {
+                    println("Reverse geocoder failed with error" + error.localizedDescription)
+                    return
                 }
-            } else {
-                println("Problem with the data received from geocoder")
-            }
-        })
+                if placemarks.count > 0 {
+                    if let placemark = placemarks.last as? CLPlacemark {
+                        self.updateView(placemark)
+                    }
+                } else {
+                    println("Problem with the data received from geocoder")
+                }
+            })
+        } else {
+            println("Geocoder is already geocoding")
+            return
+        }
     }
     
     func updateView(placemark: CLPlacemark) {
@@ -43,6 +50,6 @@ class ViewController: UIViewController {
         localityLabel.text = placemark.administrativeArea + " " + placemark.locality
         zipLabel.text = placemark.postalCode
     }
-
+    
 }
 


### PR DESCRIPTION
…safety is kept as per docs

In the documentation it says that you should only send one geocoding or reverse geocoding request at a time, by checking the BOOL and moving the geocoder into a lazily instantiated property we can guarantee this.

As it stands, it is only called once by if 'reverseGeocode:' was ever moved out of the View Controller (as it should ;) ), it would now be safe and wouldn't matter how many times we requested it - may be useful to refactor the reverseGeocode function to take an error pointer to inform the caller what happened.

It's also good practice for learning from a snippet.
